### PR TITLE
Adding installation support for Nancy SAST scanner for GoLang v1.0.0 …

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for nancy
-nancy_ver: v0.3.1
+nancy_ver: v1.0.0
 nancy_os: linux
 nancy_arch: amd64
 nancy_mirror: https://github.com/sonatype-nexus-community/nancy/releases/download
@@ -61,3 +61,14 @@ nancy_checksums:
     windows.386: sha256:378cd8c6b7fcbfe2a2d78fea3600e1a627f140dbe966e7aaf7ecb7aa9dccf0d3
     # https://github.com/sonatype-nexus-community/nancy/releases/download/v0.3.1/nancy-windows.amd64-v0.3.1.zip
     windows.amd64: sha256:ee6939f82ede52192f0a038b9bdce02a02c7d66ba5bf8a72b03d86b8ff6b72c8
+  v1.0.0:
+    # https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-darwin.amd64-v1.0.0.tar.gz
+    darwin.amd64: sha256:1d19182b98f0b80f35e029ca9169b50b89ccc65fa7872409f577a8e3d510ee6e
+    # https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-linux.amd64-v1.0.0.tar.gz
+    linux.amd64: sha256:377169cf73757b59a2a969ee5c2e022849b3f106b0965c4c6a5699193db8aa45
+    # https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-linux.386-v1.0.0.tar.gz
+    linux.386: sha256:73a5a89a37f605268a4d7facac0b91aa8caa3aaf2c94a88ee1dbb5bd1fbeb785
+    # https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-windows.386-v1.0.0.zip
+    windows.386: sha256:182337dd05f11f690ade8ebf65e69d40ac0ea60914d47840272b7f925d54ac34
+    # https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.0/nancy-windows.amd64-v1.0.0.zip
+    windows.amd64: sha256:185c263de642da99532ebafa296c1b43601014a5a1aac348b6c052a7e600af05

--- a/dl-checksum.sh
+++ b/dl-checksum.sh
@@ -31,6 +31,7 @@ dl_ver() {
 
     printf "  %s:\n" $ver
     dl $ver $lchecksums darwin amd64
+    dl $ver $lchecksums darwin 386
     dl $ver $lchecksums linux amd64
     dl $ver $lchecksums linux 386
     dl $ver $lchecksums windows 386 zip

--- a/dl-checksum.sh
+++ b/dl-checksum.sh
@@ -31,11 +31,10 @@ dl_ver() {
 
     printf "  %s:\n" $ver
     dl $ver $lchecksums darwin amd64
-    dl $ver $lchecksums darwin 386
     dl $ver $lchecksums linux amd64
     dl $ver $lchecksums linux 386
     dl $ver $lchecksums windows 386 zip
     dl $ver $lchecksums windows amd64 zip
 }
 
-dl_ver ${1:-v0.3.1}
+dl_ver ${1:-v1.0.0}


### PR DESCRIPTION
…release; dropping darwin-386 os/arch combination for release since artifact is unavailable in github releases